### PR TITLE
fix: type error

### DIFF
--- a/src/utils/get-array-range.ts
+++ b/src/utils/get-array-range.ts
@@ -1,4 +1,14 @@
 /** Generate array with number between ranges */
 export function getArrayRange(startAt: number, endAt: number): number[] {
-  return [...Array(endAt - startAt + 1).keys()].map((i) => i + startAt);
+  const iterator = Array(endAt - startAt + 1).keys();
+  const generatedArray: number[] = [];
+
+  let isDone = false;
+  while (!isDone) {
+    const nextItem = iterator.next();
+    if (nextItem.value !== undefined) generatedArray.push(nextItem.value);
+    isDone = Boolean(nextItem.done);
+  }
+
+  return generatedArray.map((i) => i + startAt);
 }


### PR DESCRIPTION
Type error: Type 'IterableIterator<number>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.